### PR TITLE
Potential fix for code scanning alert no. 130: Suspicious unused loop iteration variable

### DIFF
--- a/test_metadata.py
+++ b/test_metadata.py
@@ -810,7 +810,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
                 raise unittest.SkipTest("Protocol versions 1 and 2 are not supported in Cassandra version ".format(CASSANDRA_VERSION))
 
         for protocol_version in (1, 2):
-            cluster = TestCluster()
+            cluster = TestCluster(protocol_version=protocol_version)
             session = cluster.connect()
             self.assertEqual(cluster.metadata.keyspaces[self.keyspace_name].user_types, {})
 


### PR DESCRIPTION
Potential fix for [https://github.com/AlonaHlobina/test-OSS-repo/security/code-scanning/130](https://github.com/AlonaHlobina/test-OSS-repo/security/code-scanning/130)

To fix the issue, the `protocol_version` variable should be used in the loop body. Based on the context, it seems likely that the `TestCluster` or `session` should be configured to use the current `protocol_version` during each iteration. This would involve passing `protocol_version` as an argument to the `TestCluster` constructor or using it in some other relevant way. If the variable is genuinely not needed, it should be renamed to `_` to indicate that it is intentionally unused.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
