### PR TITLE
Potential fix for code scanning alert no. 36: Illegal raise

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -1544,6 +1544,8 @@ class ResponseWaiter(object):
         """
         self.event.wait(timeout)
         if self.error:
+            if self.error is None:
+                raise RuntimeError("An unknown error occurred, but no specific exception was set.")
             raise self.error
         elif not self.event.is_set():
             raise OperationTimedOut()


### PR DESCRIPTION
Potential fix for [https://github.com/AlonaHlobina/test-OSS-repo/security/code-scanning/36](https://github.com/AlonaHlobina/test-OSS-repo/security/code-scanning/36)

To fix the issue, we need to ensure that `self.error` is always a valid exception object when it is raised. This can be achieved by adding a check before the `raise self.error` statement. If `self.error` is `None`, we can raise a default exception (e.g., `RuntimeError`) with an appropriate message. This ensures that the code does not attempt to raise an invalid `NoneType` object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
